### PR TITLE
Update slot assignments and reduce video borders

### DIFF
--- a/aman_friend_clint-main (1)/aman_friend_clint-main/client/components/sections/ProductGrid.tsx
+++ b/aman_friend_clint-main (1)/aman_friend_clint-main/client/components/sections/ProductGrid.tsx
@@ -82,11 +82,9 @@ export default function ProductGrid() {
   // Normalize media to fixed-length array of 11
   const normalized: (string | null)[] = Array.from({ length: totalSlots }, (_, i) => provided[i] ?? null);
 
-  // Move slot 6 (index 5) content to slot 10 (index 9), leaving slot 6 empty
-  if (normalized[5]) {
-    normalized[9] = normalized[5];
-    normalized[5] = null;
-  }
+  // Assign user-provided media to slot 6 and slot 11
+  normalized[5] = "https://cdn.builder.io/o/assets%2Ffb795d15f146487ca8108581f173dd02%2F5e9b0dec61454f6da64afb298738c678?alt=media&token=47ac2eda-37d8-4759-a7df-c92aaf1ddfff&apiKey=fb795d15f146487ca8108581f173dd02";
+  normalized[10] = "https://cdn.builder.io/o/assets%2Ffb795d15f146487ca8108581f173dd02%2F7962ddc881e7420dbdb09fc0cf53063c?alt=media&token=eea120d1-c0e1-42a8-9735-26328813fe7e&apiKey=fb795d15f146487ca8108581f173dd02";
 
   const slots: Slot[] = normalized.map((video, i) => ({
     id: String(i + 1),

--- a/aman_friend_clint-main (1)/aman_friend_clint-main/client/components/sections/ProductGrid.tsx
+++ b/aman_friend_clint-main (1)/aman_friend_clint-main/client/components/sections/ProductGrid.tsx
@@ -78,9 +78,19 @@ export default function ProductGrid() {
 
   // Total slots: 11 (3 + 4 + 4) – last ones can be blank
   const totalSlots = 11;
-  let slots: Slot[] = Array.from({ length: totalSlots }).map((_, i) => ({
+
+  // Normalize media to fixed-length array of 11
+  const normalized: (string | null)[] = Array.from({ length: totalSlots }, (_, i) => provided[i] ?? null);
+
+  // Move slot 6 (index 5) content to slot 10 (index 9), leaving slot 6 empty
+  if (normalized[5]) {
+    normalized[9] = normalized[5];
+    normalized[5] = null;
+  }
+
+  const slots: Slot[] = normalized.map((video, i) => ({
     id: String(i + 1),
-    video: provided[i] ?? null,
+    video,
   }));
 
 

--- a/aman_friend_clint-main (1)/aman_friend_clint-main/client/components/sections/ProductGrid.tsx
+++ b/aman_friend_clint-main (1)/aman_friend_clint-main/client/components/sections/ProductGrid.tsx
@@ -21,12 +21,12 @@ function SlotCard({ video, selected, onSelect }: Slot & { selected: boolean; onS
       type="button"
       onClick={onSelect}
       className={cn(
-        "relative glass-card rounded-xl p-1 md:p-1.5 border-0 outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
+        "relative glass-card rounded-xl p-0.5 md:p-1 border-0 outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
         selected && "ring-1 ring-primary/70 shadow-[0_0_30px_hsl(var(--primary)/0.5)]"
       )}
       aria-pressed={selected}
     >
-      <div className="aspect-square rounded-lg overflow-hidden bg-gradient-to-br from-white/10 to-white/5 border-[0.5px] border-white/10 flex items-center justify-center">
+      <div className="aspect-square rounded-lg overflow-hidden bg-gradient-to-br from-white/10 to-white/5 border-[0.25px] border-white/10 flex items-center justify-center">
         {video ? (
           asVideo ? (
             <video
@@ -82,8 +82,9 @@ export default function ProductGrid() {
   // Normalize media to fixed-length array of 11
   const normalized: (string | null)[] = Array.from({ length: totalSlots }, (_, i) => provided[i] ?? null);
 
-  // Assign user-provided media to slot 6 and slot 11
+  // Assign user-provided media to slots 6, 10, and 11
   normalized[5] = "https://cdn.builder.io/o/assets%2Ffb795d15f146487ca8108581f173dd02%2F5e9b0dec61454f6da64afb298738c678?alt=media&token=47ac2eda-37d8-4759-a7df-c92aaf1ddfff&apiKey=fb795d15f146487ca8108581f173dd02";
+  normalized[9] = "https://cdn.builder.io/o/assets%2Ffb795d15f146487ca8108581f173dd02%2F1ab1fe5d743e4150b46c493ba0634d17?alt=media&token=c9d2ae96-b28c-4bdc-badd-74da78c8c2f2&apiKey=fb795d15f146487ca8108581f173dd02";
   normalized[10] = "https://cdn.builder.io/o/assets%2Ffb795d15f146487ca8108581f173dd02%2F7962ddc881e7420dbdb09fc0cf53063c?alt=media&token=eea120d1-c0e1-42a8-9735-26328813fe7e&apiKey=fb795d15f146487ca8108581f173dd02";
 
   const slots: Slot[] = normalized.map((video, i) => ({


### PR DESCRIPTION
## Purpose
Based on user feedback, this PR addresses requests to reorganize video slot assignments and improve visual clarity. Users wanted to move content between specific slots (6, 10, 11) and make the video borders thinner for better visibility of the bundles.

## Code changes
- **Slot assignments**: Added specific media URLs to slots 6, 10, and 11 as requested
- **Visual improvements**: 
  - Reduced padding from `p-1 md:p-1.5` to `p-0.5 md:p-1` for tighter spacing
  - Decreased border width from `border-[0.5px]` to `border-[0.25px]` for thinner, clearer borders
- **Data structure**: Refactored slot creation to use normalized array with explicit slot assignments instead of sequential mappingTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9d98efb75d7444539bab15a5627aaca8/zen-world)

👀 [Preview Link](https://9d98efb75d7444539bab15a5627aaca8-zen-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9d98efb75d7444539bab15a5627aaca8</projectId>-->
<!--<branchName>zen-world</branchName>-->